### PR TITLE
Superfolder access

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -342,6 +342,10 @@ public:
             if ((oper == rule.first) && !path.compare(0, rule.second.size(), rule.second, 0, rule.second.size()) && ( rule.second.size() == path.length() || path[rule.second.size()]=='/') ) {
                 return true;
             }
+            // pass the scope if the operation is stat of mkdir
+            if ((oper == AOP_Stat || oper == AOP_Mkdir) && !rule.second.compare(0, path.size(), path, 0, path.size()) &&  rule.second.size() >= path.length()  ) {
+                return true;
+            }
         }
         return false;
     }

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -343,7 +343,10 @@ public:
                 return true;
             }
             // pass the scope if the operation is stat of mkdir
-            if ((oper == AOP_Stat || oper == AOP_Mkdir) && !rule.second.compare(0, path.size(), path, 0, path.size()) &&  rule.second.size() >= path.length()  ) {
+            if ((oper == rule.first) && (oper == AOP_Stat || oper == AOP_Mkdir) && 
+                 rule.second.size() >= path.length() && 
+                 !rule.second.compare(0, path.size(), path, 0, path.size()) && 
+                (rule.second.size() == path.length() || rule.second[path.length()] == '/')) {
                 return true;
             }
         }

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -885,6 +885,7 @@ private:
                     xrd_rules.emplace_back(AOP_Mkdir, path);
                     xrd_rules.emplace_back(AOP_Rename, path);
                     xrd_rules.emplace_back(AOP_Excl_Insert, path);
+                    xrd_rules.emplace_back(AOP_Stat, path);
                 } else if (!strcmp(acl_authz, "modify")) {
                     paths_create_or_modify_seen.insert(path);
                     xrd_rules.emplace_back(AOP_Create, path);
@@ -893,6 +894,7 @@ private:
                     xrd_rules.emplace_back(AOP_Insert, path);
                     xrd_rules.emplace_back(AOP_Update, path);
                     xrd_rules.emplace_back(AOP_Chmod, path);
+                    xrd_rules.emplace_back(AOP_Stat, path);
                     xrd_rules.emplace_back(AOP_Delete, path);
                 } else if (!strcmp(acl_authz, "write")) {
                     paths_write_seen.insert(path);
@@ -907,6 +909,7 @@ private:
                 xrd_rules.emplace_back(AOP_Mkdir, write_path);
                 xrd_rules.emplace_back(AOP_Rename, write_path);
                 xrd_rules.emplace_back(AOP_Insert, write_path);
+                xrd_rules.emplace_back(AOP_Stat, write_path);
                 xrd_rules.emplace_back(AOP_Update, write_path);
                 xrd_rules.emplace_back(AOP_Chmod, write_path);
                 xrd_rules.emplace_back(AOP_Delete, write_path);


### PR DESCRIPTION
an additional related issue was found on a VO workflow. According to the WLCG token spec (https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md), for storage.create and storage.modify scopes:
This includes renaming files if the destination file does not already exist. This capability includes the creation of directories and subdirectories at the specified path, and the creation of any non-existent directories required to create the path itself (note the server implementation MUST NOT automatically create directories for a client).

meaning if a scope is set to storage.create:/foo/bar, the same token must be able to be used to create the /foo directory.
I've added a commit in the PR addressing this