### PR TITLE
Noscript checksum

### DIFF
--- a/src/XrdCks/XrdCksManager.cc
+++ b/src/XrdCks/XrdCksManager.cc
@@ -454,7 +454,8 @@ int XrdCksManager::Del(const char *Pfn, XrdCksData &Cks)
 int XrdCksManager::Get(const char *Pfn, XrdCksData &Cks)
 {
    XrdOucXAttr<XrdCksXAttr> xCS;
-   time_t MTime;
+   // not checking stale checksums as ceph file modification times constantly refresh on read
+   //time_t MTime;
    int rc, nFault;
 
 // Determine which checksum to get (we will accept unsupported ones as well)
@@ -473,13 +474,12 @@ int XrdCksManager::Get(const char *Pfn, XrdCksData &Cks)
    Cks = xCS.Attr.Cks;
 
 // Verify the file
-//
-   if ((rc = ModTime(Pfn, MTime))) return rc;
+// not done as ceph mod times are weird
+//   if ((rc = ModTime(Pfn, MTime))) return rc;
 
 // Return result
 //
-   return (Cks.fmTime != MTime || nFault
-       ||  Cks.Length > XrdCksData::ValuSize || Cks.Length <= 0
+   return ( nFault || Cks.Length > XrdCksData::ValuSize || Cks.Length <= 0
         ? -ESTALE : int(Cks.Length));
 }
 

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -342,6 +342,10 @@ public:
             if ((oper == rule.first) && !path.compare(0, rule.second.size(), rule.second, 0, rule.second.size()) && ( rule.second.size() == path.length() || path[rule.second.size()]=='/') ) {
                 return true;
             }
+            // pass the scope if the operation is stat of mkdir
+            if ((oper == rule.first) && (oper == AOP_Stat || oper == AOP_Mkdir) && rule.second.size() >= path.length() && !rule.second.compare(0, path.size(), path, 0, path.size()) && (rule.second.size() == path.length() || rule.second[path.length()] == '/') ) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
skip stale checksum check as this is not fit for purpose for a ceph backend.
this allows to use default checksumming mechanism